### PR TITLE
Fix bugs in uap collection.

### DIFF
--- a/uap.go
+++ b/uap.go
@@ -219,7 +219,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 				fields["radio"] = s.Radio
 				fields["state"] = s.State
 				fields["radio_tx_packets"] = s.TxPackets
-				fields["radio_tx_power"] = s.TxPower
+				fields["radio_tx_power"] = s.TxPower.Number
 				fields["radio_tx_retries"] = s.TxRetries
 				fields["user-num_sta"] = s.UserNumSta
 				break
@@ -253,7 +253,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 				fields["vap_tx_latency_max"] = s.TxLatencyMax
 				fields["vap_tx_latency_min"] = s.TxLatencyMin
 				fields["vap_tx_packets"] = s.TxPackets
-				fields["vap_tx_power"] = s.TxPower
+				fields["vap_tx_power"] = s.TxPower.Number
 				fields["vap_tx_retries"] = s.TxRetries
 				fields["usage"] = s.Usage
 				break

--- a/uap.go
+++ b/uap.go
@@ -222,41 +222,41 @@ func (u UAP) Points() ([]*influx.Point, error) {
 				fields["radio_tx_power"] = s.TxPower
 				fields["radio_tx_retries"] = s.TxRetries
 				fields["user-num_sta"] = s.UserNumSta
-				continue
+				break
 			}
 		}
 		for _, s := range u.VapTable {
 			if p.Name == s.RadioName {
 				tags["ap_mac"] = s.ApMac
 				tags["bssid"] = s.Bssid
+				tags["vap_id"] = s.ID
+				tags["vap_name"] = s.Name
+				tags["wlanconf_id"] = s.WlanconfID
 				fields["ccq"] = s.Ccq
 				fields["essid"] = s.Essid
 				fields["extchannel"] = s.Extchannel
-				tags["vap_id"] = s.ID
 				fields["is_guest"] = s.IsGuest
 				fields["is_wep"] = s.IsWep
 				fields["mac_filter_rejections"] = s.MacFilterRejections
 				fields["map_id"] = s.MapID
-				tags["vap_name"] = s.Name
-				fields["rx_bytes"] = s.RxBytes
-				fields["rx_crypts"] = s.RxCrypts
-				fields["rx_dropped"] = s.RxDropped
-				fields["rx_errors"] = s.RxErrors
-				fields["rx_frags"] = s.RxFrags
-				fields["rx_nwids"] = s.RxNwids
-				fields["rx_packets"] = s.RxPackets
-				fields["tx_bytes"] = s.TxBytes
-				fields["tx_dropped"] = s.TxDropped
-				fields["tx_errors"] = s.TxErrors
-				fields["tx_latency_avg"] = s.TxLatencyAvg
-				fields["tx_latency_max"] = s.TxLatencyMax
-				fields["tx_latency_min"] = s.TxLatencyMin
-				fields["tx_packets"] = s.TxPackets
-				fields["tx_power"] = s.TxPower
-				fields["tx_retries"] = s.TxRetries
+				fields["vap_rx_bytes"] = s.RxBytes
+				fields["vap_rx_crypts"] = s.RxCrypts
+				fields["vap_rx_dropped"] = s.RxDropped
+				fields["vap_rx_errors"] = s.RxErrors
+				fields["vap_rx_frags"] = s.RxFrags
+				fields["vap_rx_nwids"] = s.RxNwids
+				fields["vap_rx_packets"] = s.RxPackets
+				fields["vap_tx_bytes"] = s.TxBytes
+				fields["vap_tx_dropped"] = s.TxDropped
+				fields["vap_tx_errors"] = s.TxErrors
+				fields["vap_tx_latency_avg"] = s.TxLatencyAvg
+				fields["vap_tx_latency_max"] = s.TxLatencyMax
+				fields["vap_tx_latency_min"] = s.TxLatencyMin
+				fields["vap_tx_packets"] = s.TxPackets
+				fields["vap_tx_power"] = s.TxPower
+				fields["vap_tx_retries"] = s.TxRetries
 				fields["usage"] = s.Usage
-				tags["wlanconf_id"] = s.WlanconfID
-				continue
+				break
 			}
 		}
 		pt, err := influx.NewPoint("uap_radios", tags, fields, time.Now())

--- a/uap_type.go
+++ b/uap_type.go
@@ -152,7 +152,7 @@ type UAP struct {
 		Radio       string  `json:"radio"`
 		State       string  `json:"state"`
 		TxPackets   float64 `json:"tx_packets"`
-		TxPower     float64 `json:"tx_power"`
+		TxPower     FlexInt `json:"tx_power"`
 		TxRetries   float64 `json:"tx_retries"`
 		UserNumSta  float64 `json:"user-num_sta"`
 	} `json:"radio_table_stats"`
@@ -341,7 +341,7 @@ type UAP struct {
 		TxLatencyMax        float64 `json:"tx_latency_max"`
 		TxLatencyMin        float64 `json:"tx_latency_min"`
 		TxPackets           float64 `json:"tx_packets"`
-		TxPower             int     `json:"tx_power"`
+		TxPower             FlexInt `json:"tx_power"`
 		TxRetries           int     `json:"tx_retries"`
 		Up                  bool    `json:"up"`
 		Usage               string  `json:"usage"`

--- a/unidev.go
+++ b/unidev.go
@@ -82,7 +82,7 @@ type FlexBool struct {
 	String string
 }
 
-// UnmarshalJSO method converts armed/disarmed, yes/no, active/inactive or 0/1 to true/false.
+// UnmarshalJSON method converts armed/disarmed, yes/no, active/inactive or 0/1 to true/false.
 // Really it converts ready, up, t, armed, yes, active, enabled, 1, true to true. Anything else is false.
 func (f *FlexBool) UnmarshalJSON(b []byte) error {
 	f.String = strings.Trim(string(b), `"`)


### PR DESCRIPTION
An issues was reported where the `tx_power` field was being written with an integer and a float. I noticed in the code this field is actually be written to with both types (it's an `interface{}`). This contribution renames some of the fields to more correctly identify from which part of the api data struct they originated. This fixes https://github.com/davidnewhall/unifi-poller/issues/17