### PR TITLE
Use pointers....

### DIFF
--- a/clients_influx.go
+++ b/clients_influx.go
@@ -8,14 +8,14 @@ import (
 
 // Points generates Unifi Client datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (c Client) Points() ([]*influx.Point, error) {
+func (c *Client) Points() ([]*influx.Point, error) {
 	return c.PointsAt(time.Now())
 }
 
 // PointsAt generates Unifi Client datapoints for InfluxDB.
 // These points can be passed directly to influx.
 // This is just like Points(), but specify when points were created.
-func (c Client) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (c *Client) PointsAt(now time.Time) ([]*influx.Point, error) {
 	tags := map[string]string{
 		"id":                 c.ID,
 		"mac":                c.Mac,

--- a/clients_type.go
+++ b/clients_type.go
@@ -1,7 +1,7 @@
 package unifi
 
 // Clients contains a list that contains all of the unifi clients from a controller.
-type Clients []Client
+type Clients []*Client
 
 // Client defines all the data a connected-network client contains.
 type Client struct {

--- a/devices.go
+++ b/devices.go
@@ -17,20 +17,20 @@ func (u *Unifi) parseDevices(data []json.RawMessage, siteName string) *Devices {
 		// Choose which type to unmarshal into based on the "type" json key.
 		switch assetType { // Unmarshal again into the correct type..
 		case "uap":
-			dev := UAP{SiteName: siteName}
-			if u.unmarshalDevice(assetType, r, &dev) == nil {
+			dev := &UAP{SiteName: siteName}
+			if u.unmarshalDevice(assetType, r, dev) == nil {
 				dev.Name = pick(dev.Name, dev.Mac)
 				devices.UAPs = append(devices.UAPs, dev)
 			}
 		case "ugw", "usg": // in case they ever fix the name in the api.
-			dev := USG{SiteName: siteName}
-			if u.unmarshalDevice(assetType, r, &dev) == nil {
+			dev := &USG{SiteName: siteName}
+			if u.unmarshalDevice(assetType, r, dev) == nil {
 				dev.Name = pick(dev.Name, dev.Mac)
 				devices.USGs = append(devices.USGs, dev)
 			}
 		case "usw":
-			dev := USW{SiteName: siteName}
-			if u.unmarshalDevice(assetType, r, &dev) == nil {
+			dev := &USW{SiteName: siteName}
+			if u.unmarshalDevice(assetType, r, dev) == nil {
 				dev.Name = pick(dev.Name, dev.Mac)
 				devices.USWs = append(devices.USWs, dev)
 			}

--- a/ids.go
+++ b/ids.go
@@ -12,7 +12,7 @@ import (
 )
 
 // IDSList contains a list that contains all of the IDS Events on a controller.
-type IDSList []IDS
+type IDSList []*IDS
 
 // IDS holds an Intrusion Prevention System Event.
 type IDS struct {
@@ -87,8 +87,8 @@ type IDS struct {
 
 // GetIDS returns Intrusion Detection Systems events.
 // Returns all events that happened in site between from and to.
-func (u *Unifi) GetIDS(sites []Site, from, to time.Time) ([]IDS, error) {
-	data := []IDS{}
+func (u *Unifi) GetIDS(sites Sites, from, to time.Time) ([]*IDS, error) {
+	data := []*IDS{}
 	for _, site := range sites {
 		u.DebugLog("Polling Controller for IDS/IPS Data, site %s (%s) ", site.Name, site.Desc)
 		ids, err := u.GetSiteIDS(site, from, to)
@@ -102,9 +102,9 @@ func (u *Unifi) GetIDS(sites []Site, from, to time.Time) ([]IDS, error) {
 
 // GetSiteIDS is a helper to offload the for-loop work.
 // This method retreives the Intrusion Detection System Data for 1 Site.
-func (u *Unifi) GetSiteIDS(site Site, from, to time.Time) ([]IDS, error) {
+func (u *Unifi) GetSiteIDS(site *Site, from, to time.Time) ([]*IDS, error) {
 	var response struct {
-		Data []IDS `json:"data"`
+		Data []*IDS `json:"data"`
 	}
 	URIpath := fmt.Sprintf(IPSEvents, site.Name)
 	params := fmt.Sprintf(`{"start":"%v000","end":"%v000","_limit":50000}`, from.Unix(), to.Unix())
@@ -139,13 +139,13 @@ func (u *Unifi) GetSiteIDS(site Site, from, to time.Time) ([]IDS, error) {
 // These events have a timestamp, so that is used instead of any passed-in value.
 // This method generates intrusion detection datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (i IDS) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (i *IDS) PointsAt(now time.Time) ([]*influx.Point, error) {
 	return i.Points()
 }
 
 // Points generates intrusion detection datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (i IDS) Points() ([]*influx.Point, error) {
+func (i *IDS) Points() ([]*influx.Point, error) {
 	tags := map[string]string{
 		"in_iface":       i.InIface,
 		"event_type":     i.EventType,

--- a/site_influx.go
+++ b/site_influx.go
@@ -9,14 +9,14 @@ import (
 
 // Points generates Unifi Sites' datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (u Site) Points() ([]*influx.Point, error) {
+func (u *Site) Points() ([]*influx.Point, error) {
 	return u.PointsAt(time.Now())
 }
 
 // PointsAt generates Unifi Sites' datapoints for InfluxDB.
 // These points can be passed directly to influx.
 // This is just like Points(), but specify when points were created.
-func (u Site) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (u *Site) PointsAt(now time.Time) ([]*influx.Point, error) {
 	points := []*influx.Point{}
 	for _, s := range u.Health {
 		tags := map[string]string{

--- a/site_type.go
+++ b/site_type.go
@@ -1,7 +1,7 @@
 package unifi
 
 // Sites is a struct to match Devices and Clients.
-type Sites []Site
+type Sites []*Site
 
 // Site represents a site's data.
 type Site struct {

--- a/types.go
+++ b/types.go
@@ -42,9 +42,9 @@ func DiscardLogs(msg string, v ...interface{}) {
 // Devices contains a list of all the unifi devices from a controller.
 // Contains Access points, security gateways and switches.
 type Devices struct {
-	UAPs []UAP
-	USGs []USG
-	USWs []USW
+	UAPs []*UAP
+	USGs []*USG
+	USWs []*USW
 }
 
 // Unifi is what you get in return for providing a password! Unifi represents

--- a/uap_influx.go
+++ b/uap_influx.go
@@ -8,14 +8,18 @@ import (
 
 // Points generates Wireless-Access-Point datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (u UAP) Points() ([]*influx.Point, error) {
+func (u *UAP) Points() ([]*influx.Point, error) {
 	return u.PointsAt(time.Now())
 }
 
 // PointsAt generates Wireless-Access-Point datapoints for InfluxDB.
 // These points can be passed directly to influx.
 // This is just like Points(), but specify when points were created.
-func (u UAP) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (u *UAP) PointsAt(now time.Time) ([]*influx.Point, error) {
+	if u.Stat.ap == nil {
+		// Disabled devices lack stats.
+		u.Stat.ap = &ap{}
+	}
 	tags := map[string]string{
 		"id":                    u.ID,
 		"mac":                   u.Mac,

--- a/uap_influx_test.go
+++ b/uap_influx_test.go
@@ -1,0 +1,18 @@
+package unifi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUAPPoints(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	// We're just making sure an empty dataset does not crash the method.
+	// https://github.com/davidnewhall/unifi-poller/issues/82
+	u := &UAP{}
+	pts, err := u.Points()
+	a.Nil(err)
+	a.NotNil(pts)
+}

--- a/uap_type.go
+++ b/uap_type.go
@@ -308,7 +308,7 @@ type UAP struct {
 		UplinkMac        string `json:"uplink_mac"`
 		UplinkRemotePort int    `json:"uplink_remote_port"`
 	} `json:"last_uplink"`
-	Stat          *UAPStat      `json:"stat"`
+	Stat          UAPStat       `json:"stat"`
 	TxBytes       FlexInt       `json:"tx_bytes"`
 	RxBytes       FlexInt       `json:"rx_bytes"`
 	Bytes         FlexInt       `json:"bytes"`

--- a/unifi.go
+++ b/unifi.go
@@ -71,11 +71,11 @@ func (u *Unifi) getServer() error {
 }
 
 // GetClients returns a response full of clients' data from the UniFi Controller.
-func (u *Unifi) GetClients(sites []Site) (Clients, error) {
-	data := make([]Client, 0)
+func (u *Unifi) GetClients(sites Sites) (Clients, error) {
+	data := make([]*Client, 0)
 	for _, site := range sites {
 		var response struct {
-			Data []Client `json:"data"`
+			Data []*Client `json:"data"`
 		}
 		u.DebugLog("Polling Controller, retreiving UniFi Clients, site %s (%s) ", site.Name, site.Desc)
 		clientPath := fmt.Sprintf(ClientPath, site.Name)
@@ -95,7 +95,7 @@ func (u *Unifi) GetClients(sites []Site) (Clients, error) {
 }
 
 // GetDevices returns a response full of devices' data from the UniFi Controller.
-func (u *Unifi) GetDevices(sites []Site) (*Devices, error) {
+func (u *Unifi) GetDevices(sites Sites) (*Devices, error) {
 	devices := new(Devices)
 	for _, site := range sites {
 		var response struct {
@@ -116,7 +116,7 @@ func (u *Unifi) GetDevices(sites []Site) (*Devices, error) {
 // GetSites returns a list of configured sites on the UniFi controller.
 func (u *Unifi) GetSites() (Sites, error) {
 	var response struct {
-		Data []Site `json:"data"`
+		Data []*Site `json:"data"`
 	}
 	if err := u.GetData(SiteList, &response); err != nil {
 		return nil, err

--- a/usg_influx.go
+++ b/usg_influx.go
@@ -9,14 +9,14 @@ import (
 
 // Points generates Unifi Gateway datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (u USG) Points() ([]*influx.Point, error) {
+func (u *USG) Points() ([]*influx.Point, error) {
 	return u.PointsAt(time.Now())
 }
 
 // PointsAt generates Unifi Gateway datapoints for InfluxDB.
 // These points can be passed directly to influx.
 // This is just like Points(), but specify when points were created.
-func (u USG) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (u *USG) PointsAt(now time.Time) ([]*influx.Point, error) {
 	tags := map[string]string{
 		"id":                     u.ID,
 		"mac":                    u.Mac,

--- a/usw_influx.go
+++ b/usw_influx.go
@@ -8,14 +8,14 @@ import (
 
 // Points generates Unifi Switch datapoints for InfluxDB.
 // These points can be passed directly to influx.
-func (u USW) Points() ([]*influx.Point, error) {
+func (u *USW) Points() ([]*influx.Point, error) {
 	return u.PointsAt(time.Now())
 }
 
 // PointsAt generates Unifi Switch datapoints for InfluxDB.
 // These points can be passed directly to influx.
 // This is just like Points(), but specify when points were created.
-func (u USW) PointsAt(now time.Time) ([]*influx.Point, error) {
+func (u *USW) PointsAt(now time.Time) ([]*influx.Point, error) {
 	tags := map[string]string{
 		"id":                     u.ID,
 		"mac":                    u.Mac,


### PR DESCRIPTION
A bug was reported causing a crash because a pointer was never set. This contribution fixes that by setting the pointer if it's nil. I also added a very basic test that will throw a panic if the unmarshal operation fails on an empty data set. Before the fix the test failed, now it succeeds.

I also went through and cleaned up all the methods so they use pointers correctly. This should reduce the memory footprint by a few bytes by not copying data between `Points` and `PointsAt`.